### PR TITLE
Remove Gradle wrapper validation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,9 +16,6 @@ jobs:
         with:
           ref: 'grandmaster'
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
According to the [docs](https://github.com/gradle/wrapper-validation-action#reporting-failures), wrapper JARs "generated by Gradle 3.3 to 4.0 are not verifiable because those files were dynamically generated by Gradle in a non-reproducible way".

Before upgrading to a newer Gradle version, let's first make the build stable again.