### PR TITLE
Fix grgit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 // -----
 
 plugins {
-	id 'org.ajoberstar.grgit' version '4.1.0'
+	id 'org.ajoberstar.grgit' version '4.1.1'
 }
 
 ext {


### PR DESCRIPTION
According to the grgit
[release notes](https://github.com/ajoberstar/grgit/releases/tag/4.1.1),
4.1.0 broke Java 8 compatability.

Relates to: #29
PR: #31