### PR TITLE
Fix missing tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ def insertProjectVersion(String project, String abbreviation) {
 			.sort { it.commit.dateTime }
 			.last()
 			.name
-	if (!latestTagName?.startsWith("v"))
+	if (!latestTagName.startsWith("v"))
 		throw new IllegalStateException("Could not determine version of ${project}.")
 	String version = latestTagName.substring(1)
 

--- a/build.gradle
+++ b/build.gradle
@@ -120,12 +120,17 @@ task insertVersion() {
 }
 
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Tag
 
 def insertProjectVersion(String project, String abbreviation) {
-	String latestTagName = Grgit
+	List<Tag> tags = Grgit
 			.open(dir: project)
 			.tag
 			.list()
+	if (tags.isEmpty())
+		throw new IllegalStateException("No tags available for ${project}.")
+
+	String latestTagName = tags
 			.sort { it.commit.dateTime }
 			.last()
 			.name

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 // -----
 
 plugins {
-	id 'org.ajoberstar.grgit' version '4.1.1'
+	id 'org.ajoberstar.grgit' version '4.1.1' apply false
 }
 
 ext {
@@ -119,9 +119,10 @@ task insertVersion() {
 	}
 }
 
-import org.ajoberstar.grgit.Tag
+import org.ajoberstar.grgit.Grgit
+
 def insertProjectVersion(String project, String abbreviation) {
-	String latestTagName = grgit
+	String latestTagName = Grgit
 			.open(dir: project)
 			.tag.list()
 			.sort { it.commit.dateTime }

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ def insertProjectVersion(String project, String abbreviation) {
 			.last()
 			.name
 	if (!latestTagName?.startsWith("v"))
-		throw new IllegalStateException("Could not determine version of @${project}.")
+		throw new IllegalStateException("Could not determine version of ${project}.")
 	String version = latestTagName.substring(1)
 
 	File about = file("site-source/_pages/${abbreviation}.adoc")

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,8 @@ import org.ajoberstar.grgit.Grgit
 def insertProjectVersion(String project, String abbreviation) {
 	String latestTagName = Grgit
 			.open(dir: project)
-			.tag.list()
+			.tag
+			.list()
 			.sort { it.commit.dateTime }
 			.last()
 			.name

--- a/git-repo-setup.sh
+++ b/git-repo-setup.sh
@@ -4,7 +4,7 @@
 set -e
 
 # cloning `junit-pioneer`
-git clone https://github.com/junit-pioneer/junit-pioneer.git junit-pioneer --depth=10
+git clone https://github.com/junit-pioneer/junit-pioneer.git junit-pioneer
 # adding worktrees `site` and `site-source`
 git checkout master
 git checkout site-source


### PR DESCRIPTION
After #31 and #30, here comes fix no. 3! 😉

Proposed commit message:

```text
Fix missing tags (#32)

When the GitHub Actions workflow is triggered on an event other than
`triggerSiteBuild`, we don't know the depth of the last tagged commit.
Therefore, we can no longer add the `depth` flag when cloning the
JUnit Pioneer repo.

Furthermore, this PRs improves error handling when inserting the
project version.

Relates to: #29
PR: #32
```